### PR TITLE
Allow 5/6/7/M extras to be scrambled on an unsolved puzzle

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -222,7 +222,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 ## <article-4><scrambling><scrambling> Article 4: Scrambling
 
 - 4a) A scrambler applies scramble sequences to the solved puzzles.
-    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate.
+    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate. This exception does not apply to regular scramble sequences which are not used for extra attempts.
     - 4a1+) [RECOMMENDATION] The WCA Delegate should use stronger discretion when determining whether or not the scramble sequence may be applied to an unsolved puzzle for 5x5x5 Cube and Megaminx.
 - 4b) Competition scramble sequences must be generated using a current official version of an official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
 - 4b+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -222,7 +222,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 ## <article-4><scrambling><scrambling> Article 4: Scrambling
 
 - 4a) A scrambler applies scramble sequences to the solved puzzles.
-    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the Discretion of the WCA Delegate.
+    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate.
     - 4a1+) [RECOMMENDATION] The WCA Delegate should use stronger discretion when determining whether or not the scramble sequence may be applied to an unsolved puzzle for 5x5x5 Cube and Megaminx.
 - 4b) Competition scramble sequences must be generated using a current official version of an official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
 - 4b+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -222,7 +222,8 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 ## <article-4><scrambling><scrambling> Article 4: Scrambling
 
 - 4a) A scrambler applies scramble sequences to the solved puzzles.
-    - 4a1) Exception: for extra attempts for 6x6x6 Cube, 7x7x7 Cube, and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the Discretion of the WCA Delegate.
+    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the Discretion of the WCA Delegate.
+    - 4a1+) [RECOMMENDATION] The WCA Delegate should use stronger discretion when determining whether or not the scramble sequence may be applied to an unsolved puzzle for 5x5x5 Cube and Megaminx.
 - 4b) Competition scramble sequences must be generated using a current official version of an official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
 - 4b+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.
 - 4b++) [REMINDER] If the WCA Delegate generates any additional scramble sequences during the competition, the scramble sequences must be saved.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -222,7 +222,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 ## <article-4><scrambling><scrambling> Article 4: Scrambling
 
 - 4a) A scrambler applies scramble sequences to the solved puzzles.
-    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate. This exception does not apply to regular scramble sequences which are not used for extra attempts.
+    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate. This exception does not apply to scramble sequences which are not used for extra attempts.
     - 4a1+) [RECOMMENDATION] The WCA Delegate should use stronger discretion when determining whether or not the scramble sequence may be applied to an unsolved puzzle for 5x5x5 Cube and Megaminx.
 - 4b) Competition scramble sequences must be generated using a current official version of an official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
 - 4b+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -221,7 +221,8 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 
 ## <article-4><scrambling><scrambling> Article 4: Scrambling
 
-- 4a) A scrambler applies scramble sequences to the puzzles.
+- 4a) A scrambler applies scramble sequences to the solved puzzles.
+    - 4a1) Exception: for extra attempts for 6x6x6 Cube, 7x7x7 Cube, and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the Discretion of the WCA Delegate.
 - 4b) Competition scramble sequences must be generated using a current official version of an official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
 - 4b+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.
 - 4b++) [REMINDER] If the WCA Delegate generates any additional scramble sequences during the competition, the scramble sequences must be saved.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -222,7 +222,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 ## <article-4><scrambling><scrambling> Article 4: Scrambling
 
 - 4a) A scrambler applies scramble sequences to the solved puzzles.
-    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate. This exception only applies to scramble sequences for extra attempts.
+    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate. This exception only applies to scramble sequences for extra attempts. When applying a scramble sequence to an unsolved puzzle, the scramble may begin in any orientation, the usual requirements in [Regulation 4d](regulations:regulation:4d) do not apply.
     - 4a1+) [RECOMMENDATION] The WCA Delegate should use stronger discretion when determining whether or not the scramble sequence may be applied to an unsolved puzzle for 5x5x5 Cube and Megaminx.
 - 4b) Competition scramble sequences must be generated using a current official version of an official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
 - 4b+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -222,7 +222,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 ## <article-4><scrambling><scrambling> Article 4: Scrambling
 
 - 4a) A scrambler applies scramble sequences to the solved puzzles.
-    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate. This exception does not apply to scramble sequences which are not used for extra attempts.
+    - 4a1) Exception: for extra attempts for 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube and Megaminx, the scramble sequence may be applied to an unsolved puzzle, at the discretion of the WCA Delegate. This exception only applies to scramble sequences for extra attempts.
     - 4a1+) [RECOMMENDATION] The WCA Delegate should use stronger discretion when determining whether or not the scramble sequence may be applied to an unsolved puzzle for 5x5x5 Cube and Megaminx.
 - 4b) Competition scramble sequences must be generated using a current official version of an official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
 - 4b+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.


### PR DESCRIPTION
- Clarify that scrambling starts with a solved puzzle.
- Allow extra attempts on 5x5, 6x6, 7x7 and megaminx to be scrambled on an unsolved puzzle, under Delegate discretion.
- Stronger discretion for 5x5 and megaminx.