### PR TITLE
9l1++ consistency update

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -360,7 +360,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - 9l) Each round must be completed before any following round of the same event can start. Exception: Extra attempts may be given at any point during a competition to replace an attempt that was initially invalid.
     - 9l1) An attempt is considered invalid if an extra attempt is required to be granted.
     - 9l1+) [CLARIFICATION] A DNF Result is generally considered a valid result. Extra attempts must not be given for using a non-permitted puzzle that is only found after the round is complete (see [Regulation 3k2a](regulations:regulation:3k2a)).
-    - 9l1++) [EXAMPLE] Examples of an invalid attempt: an attempt that was incorrectly scrambled, attempts where the results are no longer retrievable (e.g. a missing scorecard).
+    - 9l1++) [EXAMPLE] Examples of an invalid attempt: an attempt within the scope of [Regulation 11i1](regulations:regulation:11i1) that was incorrectly scrambled, attempts where the results are no longer retrievable (e.g. a missing scorecard).
 - 9m) Events must have at most four rounds.
     - 9m1) Rounds with 99 or fewer competitors must have at most two subsequent rounds.
     - 9m2) Rounds with 15 or fewer competitors must have at most one subsequent round.


### PR DESCRIPTION
9l1++ may be misleading following changes to misscramble requirements in the 2025-01-01 Regulations. This change clarifies existing practice.