### PR TITLE
Clarify B3c exception

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -675,7 +675,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - B3) Memorization phase:
     - B3a) The competitor may pick up the puzzle during the memorization phase.
     - B3b) The competitor must not make physical notes. Penalty: disqualification of the attempt (DNF).
-    - B3c) The competitor must not apply moves or intentional changes in alignment (see [Regulation A3c2](regulations:regulation:A3c2)) to the puzzle during the memorization phase. Penalty: disqualification of the attempt (DNF).
+    - B3c) The competitor must not apply moves or intentional changes in alignment (see [Regulation A3c2](regulations:regulation:A3c2)) to the puzzle during the memorization phase. Penalty: disqualification of the attempt (DNF). Exception: see [Regulation B3d](regulations:regulation:B3d).
     - B3d) If the parts of the puzzle are not fully aligned, then the competitor may align the faces, as long as misalignments stay within the limits of [Regulation 10f](regulations:regulation:10f) (see [Regulation A3c2](regulations:regulation:A3c2)).
 - B4) Blindfolded phase:
     - B4a) The competitor dons the blindfold to start the blindfolded phase.


### PR DESCRIPTION
Note that B3c has an exception. Although B3d is the next Regulation, this could still be missed, and the wording approach is consistent with the corresponding Regulation in Article A, A3c1.