### PR TITLE
Remove 10h

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -417,7 +417,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 10f4+) [CLARIFICATION] When counting the moves in case of a misalignment at the end of a solve, X and Y are considered separately. Example: (5, 1) is considered one misalignment, (5, 5) is considered two misalignments.
 - 10i) The solved state of Clock is achieved when all eighteen inner clock faces point to 12 o'clock.
     - 10i1) Inner clock faces that do not clearly point to a particular hour marker are considered to point to the nearest hour marker.
-    - 10hi2) The solved state of Clock is not affected by loose or popped pin caps.
+    - 10i2) The solved state of Clock is not affected by loose or popped pin caps.
 
 
 ## <article-11><incidents><incidents> Article 11: Incidents


### PR DESCRIPTION
10h was not required as all current puzzles other than Clock are judged according to 10e.