### PR TITLE
Clarify extra timing

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -357,7 +357,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 9i3) If the WCA Regulations for an event are changed, existing regional records stand until they are broken under the new WCA Regulations.
 - 9j) Each event must be held at most once per competition.
 - 9k) All competitors may participate in all events of a competition, except in cases specifically approved by the WCA Competition Announcement Team.
-- 9l) Each round must be completed before any following round of the same event can start. Exception: Extra attempts may be given at any point during a competition to replace an attempt that was initially invalid.
+- 9l) Each round must be completed before any following round of the same event can start. Exception: Extra attempts may be given at any point during a competition to replace an attempt that was initially invalid, but must not be given after the competition has ended (see [Regulation 9u](regulations:regulation:9u)).
     - 9l1) An attempt is considered invalid if an extra attempt is required to be granted.
     - 9l1+) [CLARIFICATION] A DNF Result is generally considered a valid result. Extra attempts must not be given for using a non-permitted puzzle that is only found after the round is complete (see [Regulation 3k2a](regulations:regulation:3k2a)).
     - 9l1++) [EXAMPLE] Examples of an invalid attempt: an attempt that was incorrectly scrambled, attempts where the results are no longer retrievable (e.g. a missing scorecard).

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -357,8 +357,8 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 9i3) If the WCA Regulations for an event are changed, existing regional records stand until they are broken under the new WCA Regulations.
 - 9j) Each event must be held at most once per competition.
 - 9k) All competitors may participate in all events of a competition, except in cases specifically approved by the WCA Competition Announcement Team.
-- 9l) Each round must be completed before any following round of the same event can start. Exception: Extra attempts may be given at any point during a competition to replace an attempt that was initially invalid, but must not be given after the competition has ended (see [Regulation 9u](regulations:regulation:9u)).
-    - 9l1) An attempt is considered invalid if an extra attempt is required to be granted.
+- 9l) Each round must be completed before any following round of the same event can start. The following exceptions apply:
+    - 9l1) Extra attempts may be given at any point during a competition to replace an attempt that was initially invalid, but must not be given after the competition has ended (see [Regulation 9u](regulations:regulation:9u)). An attempt is considered invalid if an extra attempt is required to be granted.
     - 9l1+) [CLARIFICATION] A DNF Result is generally considered a valid result. Extra attempts must not be given for using a non-permitted puzzle that is only found after the round is complete (see [Regulation 3k2a](regulations:regulation:3k2a)).
     - 9l1++) [EXAMPLE] Examples of an invalid attempt: an attempt that was incorrectly scrambled, attempts where the results are no longer retrievable (e.g. a missing scorecard).
 - 9m) Events must have at most four rounds.


### PR DESCRIPTION
Clarify, in line with existing understanding, that extras can only be given during the competition.